### PR TITLE
Moved start time var assignment outside of .then()

### DIFF
--- a/src/interface/cucumber.js
+++ b/src/interface/cucumber.js
@@ -100,9 +100,8 @@ function _createEventBroadcaster(suite) {
             }
             subSuite = new Suite.default({ name: name });
             suite.add(subSuite);
-            subSuite.executor.emit('suiteStart', subSuite).then(() => {
-                subSuiteStart = Date.now();
-            });
+            subSuite.executor.emit('suiteStart', subSuite);
+            subSuiteStart = Date.now();
         } catch(e) {
             suite.error = e;
             console.log(e);
@@ -128,9 +127,8 @@ function _createEventBroadcaster(suite) {
             }
             test = new Test.default({ name, test: () => {} });
             subSuite.add(test);
-            test.executor.emit('testStart', test).then(() => {
-                testStart = Date.now();
-            });
+            test.executor.emit('testStart', test);
+            testStart = Date.now();
         } catch(e) {
             suite.error = e;
             console.log(e);


### PR DESCRIPTION
Both subSuiteStart and testStart were undefined at the time of the end-event handlers needing to use them. This resulted in the time elapsed console output being "(NaNs)". The values were actually being set after the time elapsed calculation was performed. By moving those two assignments, the values are now set before they are used.